### PR TITLE
Add server entypoint script to manage docker secrets

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -28,6 +28,6 @@ RUN npm run build \
 
 EXPOSE 3333
 
-ENTRYPOINT ["npm"]
+ENTRYPOINT ["./entrypoint.sh"]
 
 CMD ["start"]

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -x
+
+if [[ ! -z $SENDGRID_API_KEY_FILE ]]; then
+  export SENDGRID_API_KEY=$(cat $SENDGRID_API_KEY_FILE)
+fi
+
+exec npm "$@"


### PR DESCRIPTION
Tomoscan-server will now use an entrypoint to convert docker secrets into env var.