### PR TITLE
fix warning prop "block" expected String, got Number.

### DIFF
--- a/client/pages/blocks/_slug.vue
+++ b/client/pages/blocks/_slug.vue
@@ -235,7 +235,7 @@ export default {
     created () {
         let number = this.$route.params.slug
         if (number) {
-            this.number = number
+            this.number = number.toString()
         }
     },
     async mounted () {


### PR DESCRIPTION
ISSUE: 
1. Go to /blocks
2. Choose a random block
A warning show up in the console window
![screenshot from 2018-09-21 14-32-39](https://user-images.githubusercontent.com/24842503/45866844-31a93f00-bdac-11e8-9e58-a40b114b6302.png)
DONE:
convert block number to string in block _slug file, so it won't impact to _slug's children components