### PR TITLE
Fix queue not found

### DIFF
--- a/server/src/crawl.js
+++ b/server/src/crawl.js
@@ -18,6 +18,7 @@ fs.readdirSync(path.join(__dirname, 'queues'))
 
         await ch.prefetch(1)
         logger.info(' [*] Waiting for messages in %s. To exit press CTRL+C', consumer.name)
+        ch.assertQueue(consumer.name, { durable: false })
         ch.consume(consumer.name, async function (msg) {
             const content = msg.content.toString()
             consumer.task(JSON.parse(content))


### PR DESCRIPTION
Follows this https://github.com/squaremo/amqp.node/issues/175.
Tested.
```
20|tomoscan-crawler  | 2020-11-03T10:35:48.569Z INFO:  [*] Waiting for messages in TransactionProcess. To exit press CTRL+C
20|tomoscan-crawler  | events.js:174
20|tomoscan-crawler  |       throw er; // Unhandled 'error' event
20|tomoscan-crawler  |       ^
20|tomoscan-crawler  | Error: Channel closed by server: 404 (NOT-FOUND) with message "NOT_FOUND - no queue 'RewardProcess' in vhost '/'"
20|tomoscan-crawler  |     at Channel.C.accept (/data/tomochain/tomoscan/server/node_modules/amqplib/lib/channel.js:422:17)
20|tomoscan-crawler  |     at Connection.mainAccept [as accept] (/data/tomochain/tomoscan/server/node_modules/amqplib/lib/connection.js:64:33)
20|tomoscan-crawler  |     at Socket.go (/data/tomochain/tomoscan/server/node_modules/amqplib/lib/connection.js:478:48)
20|tomoscan-crawler  |     at Socket.emit (events.js:198:13)
20|tomoscan-crawler  |     at emitReadable_ (_stream_readable.js:539:12)
20|tomoscan-crawler  |     at process._tickCallback (internal/process/next_tick.js:63:19)
20|tomoscan-crawler  | Emitted 'error' event at:
20|tomoscan-crawler  |     at Connection.emit (events.js:198:13)
20|tomoscan-crawler  |     at Connection.C.onSocketError (/data/tomochain/tomoscan/server/node_modules/amqplib/lib/connection.js:353:10)
20|tomoscan-crawler  |     at Connection.emit (events.js:198:13)
20|tomoscan-crawler  |     at Socket.go (/data/tomochain/tomoscan/server/node_modules/amqplib/lib/connection.js:481:12)
20|tomoscan-crawler  |     at Socket.emit (events.js:198:13)
20|tomoscan-crawler  |     at emitReadable_ (_stream_readable.js:539:12)
20|tomoscan-crawler  |     at process._tickCallback (internal/process/next_tick.js:63:19)

```